### PR TITLE
Update vj_pairing_plot.r

### DIFF
--- a/src/main/resources/rscripts/vj_pairing_plot.r
+++ b/src/main/resources/rscripts/vj_pairing_plot.r
@@ -20,6 +20,9 @@ mat <- matrix(apply(temp[2:n, 2:m], 1:2, as.numeric), n - 1, m-1) * 100
 n <- nrow(temp)
 m <- ncol(temp)
 
+rn[rn == "unresolved"] <- "unresolved.J"
+cn[cn == "unresolved"] <- "unresolved.V"
+
 rownames(mat) <- rn
 colnames(mat) <- cn
 


### PR DESCRIPTION
This modification enables VJ-circos plots from ImmunoSeq data, which otherwise usually fails due to the presence of unresolved J AND V families. Attached file for testing.
[5.P1_m4.fancyvj.wt.txt](https://github.com/mikessh/vdjtools/files/87423/5.P1_m4.fancyvj.wt.txt)
