### PR TITLE
Documentation update wrt R packages in Debian

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -89,8 +89,8 @@ circlize
 FField
 ggplot2       r-cran-ggplot2
 gplots        r-cran-gplots
-grid
-gridExtra
+grid          r-cran-gridbase
+gridExtra     r-cran-gridextra
 MASS          r-cran-mass
 plotrix       r-cran-plotrix
 RColorBrewer  r-cran-rcolorbrewer
@@ -108,13 +108,13 @@ Debian and Debian based distributions such as Ubuntu and Mint:
 
     apt-get install r-cran-ape r-cran-ggplot2 r-cran-gplots r-cran-mass \
       r-cran-plotrix r-cran-rcolorbrewer r-cran-reshape r-cran-reshape2 \
-      r-cran-scales
+      r-cran-scales r-cran-gridbase r-cran-gridextra
 
 while the other packages will have to be installed via R itself:
 
 .. code:: r
 
-    install.packages(c("circlize", "grid", "gridExtra", "VennDiagram"))
+    install.packages(c("circlize", "FField", "VennDiagram"))
 
 Alternatively, VDJtools has a ref:`Rinstall` routine:
 


### PR DESCRIPTION
Hello, I am working to get your VDJtools into the Debian distribution. You will for instance find https://tracker.debian.org/pkg/milib to be recently added to the distribution. I am about to finalize the packaging on VDJtools on https://salsa.debian.org/java-team/vdjtools . It seems to like quite fine, but for instance I have no idea if /usr/share/vdjtools/main/rscripts/fancy_spectratype.r should be the right path for your scripts. The .jar file resides in /usr/share/java but could happily move elsewhere with a symbolic link to that default directory. If you have any vision about what a Debian package for VDJtools should look like - please tell me.
Cheers,
Steffen
