### PR TITLE
Adding /usr/share/java to gradle repo path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ mainClassName = 'com.antigenomics.vdjtools.VdjTools'
 repositories {
     mavenCentral()
     maven { url 'https://jitpack.io' }
+    flatDir { dirs '/usr/share/java' }
 }
 
 jar {


### PR DESCRIPTION
Hello,

Debian places .jar files in the directory "/usr/share/java". This patch supports gradle to find these.
All build dependencies are already shipping with Debian.
I apologize for the extra diff on the missing final newline that github's editor auto-added.

Cheers,

Steffen