### PR TITLE
Release v2.4.0 — arda becomes a base dependency (ships the germline reference)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,8 +24,12 @@ sphinx-build -W --keep-going -b html docs docs/_build/html        # docs gate (z
 ```
 Co-developed parents are early-alpha: `bash setup.sh --dev-parents` editable-installs
 `../seqtree ../arda ../vdjmatch` if present (else PyPI: `seqtree`, `arda-mapper`, `vdjmatch`).
-Deps trace to real imports — `arda-mapper`/`vdjmatch` live in the `[model]`/`[overlap]` extras
-until the phase that imports them promotes them to base deps.
+Deps trace to real imports — a phase's parent is promoted from an extra to a base dep once it
+lands. **`arda-mapper` is a BASE dep** (since v2.4.0): a plain `pip install vdjtools` must ship
+the model engine *and* the germline reference, because downstream libs (mirpy) depend on vdjtools
+*for* that reference. It's imported lazily, so `import vdjtools` stays light; mmseqs2 is needed
+only for arda's annotate path. `vdjmatch`/`seqtree` remain the `[overlap]` extra. `[model]` is a
+kept-but-empty alias so existing `vdjtools[model]` pins still resolve.
 
 ## Git model
 `master` = v2 (tagged releases) ← `dev` (integration) ← `feature/*` (one per phase).
@@ -71,8 +75,8 @@ each event's `given`). VJ loci degrade cleanly (no D tables). Bootstrap data: mi
   organism)` from arda (`cdr3fix.load_anchors` + `d_germlines.fasta`), `cut_segment` palindrome
   derivation (reproduces OLGA's cut segs), `reconcile_olga` audit. Shared frame verified vs OLGA
   (`tests/python/test_reference.py`). `from_olga` deliberately keeps OLGA germline (exact-Pgen
-  invariant); arda is canonical for arda-native models + scenarios + stitching. arda is the `[model]`
-  extra (`pip install -e ../arda` for dev). Gap: arda ships no full-length V/J germline (needs a
+  invariant); arda is canonical for arda-native models + scenarios + stitching. arda is a **base
+  dep** (`pip install -e ../arda` for dev). Gap: arda ships no full-length V/J germline (needs a
   helper) — a **P1c/stitching prerequisite**.
 - **DONE aa Pgen** `model/pgen.py::pgen_aa` — codon-marginalizing left-to-right DP. VJ is fast;
   VDJ enumerates D placements + a multi-block DP handling the DJ insertion 3'→5' (reference impl:

--- a/README.md
+++ b/README.md
@@ -41,12 +41,21 @@ pip install vdjtools
 ```
 
 Prebuilt wheels ship for CPython 3.10–3.13 on Linux, macOS (Apple Silicon), and Windows; the
-native `_core` C++ extension is bundled (the source distribution compiles it on install). The
-pure-analytics paths (diversity / spectratype / usage / overlap) work out of the box; the model
-and annotation paths additionally pull in [arda](https://github.com/antigenomics/arda) (MMseqs2):
+native `_core` C++ extension is bundled (the source distribution compiles it on install).
+
+That one command gives you **the whole model engine and the germline reference**: the bundled
+per-locus V(D)J models, Pgen / generation / EM, and the V/D/J germline + CDR3 anchors — because
+[arda](https://github.com/antigenomics/arda), the single source of germline truth, is a **base
+dependency** (it is imported lazily, so `import vdjtools` stays light). arda fetches its IMGT
+reference once, on first use. Downstream libraries can therefore depend on plain `vdjtools` and
+rely on `vdjtools.model.reference.load_germline(...)` being there.
+
+MMseqs2 is needed **only** for arda's alignment/annotation path (`model.stitch.annotate`), never
+for germline lookup, Pgen, generation or the analytics — install it via conda/brew if you need it.
+Repertoire overlap / TCRnet pull in the seqtree engine:
 
 ```bash
-pip install "vdjtools[model]"
+pip install "vdjtools[overlap]"
 ```
 
 ### Development

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,7 @@
 project = "vdjtools"
 author = "ISALGO laboratory"
 copyright = "2026, ISALGO laboratory"
-version = release = "2.3.0"
+version = release = "2.3.1"
 
 extensions = [
     "sphinx.ext.autodoc",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,7 @@
 project = "vdjtools"
 author = "ISALGO laboratory"
 copyright = "2026, ISALGO laboratory"
-version = release = "2.3.1"
+version = release = "2.4.0"
 
 extensions = [
     "sphinx.ext.autodoc",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "vdjtools"  # if the PyPI name is taken, fall back to a distinct dist name (cf. arda -> arda-mapper)
-version = "2.3.1"
+version = "2.4.0"
 description = "TCR/BCR repertoire analysis — Pgen/generation/inference, diversity, overlap, biomarkers (Python + C++)"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -27,13 +27,23 @@ dependencies = [
     "numpy",
     "scipy",
     "typer>=0.12",  # the `vdjtools` CLI (Phase 8) is a core entry point
+    # arda = the single source of germline truth (see model/reference.py): V/D/J germline +
+    # CDR3 anchors for every locus, contig stitching/annotation, and the arda-native model
+    # builder. Phase 1 landed, so it is promoted to a base dep: a plain `pip install vdjtools`
+    # must ship the model engine AND the germline reference, because downstream libraries
+    # (mirpy) depend on vdjtools *for* that reference and cannot be expected to opt into an
+    # extra. Cheap to require: same wheel matrix as vdjtools (cp310-313 x mac/linux/win) and
+    # its only runtime deps are polars + typer (already ours) + requests. It is imported
+    # lazily inside the functions that need it, so `import vdjtools` stays light. mmseqs2 is
+    # needed only for arda's alignment/annotate path, never for germline lookup or Pgen.
+    "arda-mapper>=2.5.3",
 ]
 
 [project.scripts]
 vdjtools = "vdjtools.cli:app"
 
 [project.optional-dependencies]
-model = ["arda-mapper>=2.5.3"]         # Phase 1: scenario enumeration + markup repair (brings mmseqs2)
+model = []                             # DEPRECATED no-op alias: arda-mapper is a BASE dep since v2.4.0 (the model engine + germline reference ship with a plain `pip install vdjtools`). Kept so existing `vdjtools[model]` pins (e.g. mirpy's) keep resolving.
 overlap = ["vdjmatch>=0.0.1", "seqtree>=0.3", "scikit-learn"]  # Phase 4: overlap + TCRnet (brings the seqtree engine); sklearn for MDS clustering; seqtree for similarity-weighted (TINA) overlap
 preprocess = ["seqtree>=0.3"]          # Phase 5: freq-based error correction (near-neighbour search)
 sc = ["scikit-learn", "pyyaml", "anndata", "huggingface_hub"]  # Phase 7: single-cell — sklearn for cluster_eval contingency, pyyaml for AIRR Cell export, anndata for the scverse bridge (to_anndata), HF for the dCODE benchmark fetch (tests only)
@@ -43,7 +53,7 @@ test = ["pytest>=7.4", "pytest-cov"]
 bench = ["huggingface_hub"]  # test-only: real-data fetch; never a runtime dep
 docs = ["sphinx>=7", "pydata-sphinx-theme>=0.15", "nbsphinx"]
 dev = ["ruff", "pytest>=7.4", "pybind11>=2.12"]
-all = ["arda-mapper>=2.5.3", "vdjmatch>=0.0.1"]
+all = ["vdjmatch>=0.0.1", "seqtree>=0.3", "scikit-learn"]  # arda-mapper is a base dep (not an extra)
 
 [project.urls]
 Homepage = "https://github.com/antigenomics/vdjtools"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "vdjtools"  # if the PyPI name is taken, fall back to a distinct dist name (cf. arda -> arda-mapper)
-version = "2.3.0"
+version = "2.3.1"
 description = "TCR/BCR repertoire analysis — Pgen/generation/inference, diversity, overlap, biomarkers (Python + C++)"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -33,7 +33,7 @@ dependencies = [
 vdjtools = "vdjtools.cli:app"
 
 [project.optional-dependencies]
-model = ["arda-mapper>=2.5"]           # Phase 1: scenario enumeration + markup repair (brings mmseqs2)
+model = ["arda-mapper>=2.5.3"]         # Phase 1: scenario enumeration + markup repair (brings mmseqs2)
 overlap = ["vdjmatch>=0.0.1", "seqtree>=0.3", "scikit-learn"]  # Phase 4: overlap + TCRnet (brings the seqtree engine); sklearn for MDS clustering; seqtree for similarity-weighted (TINA) overlap
 preprocess = ["seqtree>=0.3"]          # Phase 5: freq-based error correction (near-neighbour search)
 sc = ["scikit-learn", "pyyaml", "anndata", "huggingface_hub"]  # Phase 7: single-cell — sklearn for cluster_eval contingency, pyyaml for AIRR Cell export, anndata for the scverse bridge (to_anndata), HF for the dCODE benchmark fetch (tests only)
@@ -43,7 +43,7 @@ test = ["pytest>=7.4", "pytest-cov"]
 bench = ["huggingface_hub"]  # test-only: real-data fetch; never a runtime dep
 docs = ["sphinx>=7", "pydata-sphinx-theme>=0.15", "nbsphinx"]
 dev = ["ruff", "pytest>=7.4", "pybind11>=2.12"]
-all = ["arda-mapper>=2.5", "vdjmatch>=0.0.1"]
+all = ["arda-mapper>=2.5.3", "vdjmatch>=0.0.1"]
 
 [project.urls]
 Homepage = "https://github.com/antigenomics/vdjtools"

--- a/python/vdjtools/__init__.py
+++ b/python/vdjtools/__init__.py
@@ -13,5 +13,5 @@ vdjmatch/seqtree) until a feature that needs them is used.
 """
 from ._core import hamming
 
-__version__ = "2.3.1"
+__version__ = "2.4.0"
 __all__ = ["hamming", "__version__"]

--- a/python/vdjtools/__init__.py
+++ b/python/vdjtools/__init__.py
@@ -13,5 +13,5 @@ vdjmatch/seqtree) until a feature that needs them is used.
 """
 from ._core import hamming
 
-__version__ = "2.3.0"
+__version__ = "2.3.1"
 __all__ = ["hamming", "__version__"]

--- a/python/vdjtools/model/infer.py
+++ b/python/vdjtools/model/infer.py
@@ -472,7 +472,7 @@ def arda_masks(contigs: list[str], model: Model, *, organism: str = "human") -> 
     """Annotate nt contigs with arda and build ``(junctions, masks)`` for masked :func:`infer`.
 
     The production path for real reads: ``junctions, masks = arda_masks(contigs, template);
-    infer_native(template, junctions, masks=masks)``. arda is the ``[model]`` extra.
+    infer_native(template, junctions, masks=masks)``. arda is a base dependency (ships with vdjtools).
     """
     from .stitch import annotate
 

--- a/python/vdjtools/model/io.py
+++ b/python/vdjtools/model/io.py
@@ -380,7 +380,8 @@ def from_arda(locus: str, organism: str = "human", *,
         A validated :class:`Model` (VDJ if arda has D germline for the locus, else VJ).
 
     Raises:
-        ImportError: If arda (the ``[model]`` extra) is not installed.
+        ImportError: If arda is not importable (it is a base dependency; a plain
+            ``pip install vdjtools`` ships it).
         ValueError: If arda has no germline for ``locus`` / ``organism``.
     """
     from . import reference as ref

--- a/python/vdjtools/model/reference.py
+++ b/python/vdjtools/model/reference.py
@@ -94,10 +94,11 @@ def load_germline(locus: str, organism: str = "human") -> pl.DataFrame:
         ``sequence`` is the full D germline, ``cdr3_anchor = -1``.
 
     Raises:
-        ImportError: If arda (the ``[model]`` extra) is not installed.
+        ImportError: If arda is not importable (it is a base dependency; a plain
+            ``pip install vdjtools`` ships it).
         ValueError: If no germline is found for ``locus`` / ``organism``.
     """
-    from arda.cdr3fix import load_anchors  # optional dep (the [model] extra)
+    from arda.cdr3fix import load_anchors  # base dep; imported lazily to keep `import vdjtools` light
     from arda.paths import vdj_dir
     from arda.refbuild.imgt import read_fasta
 
@@ -159,7 +160,8 @@ def load_full_vj_germline(organism: str = "human") -> dict[tuple[str, str], str]
         arda markup are present; pseudogenes (in the CDR3 anchors) may be missing.
 
     Raises:
-        ImportError: If arda (the ``[model]`` extra) is not installed.
+        ImportError: If arda is not importable (it is a base dependency; a plain
+            ``pip install vdjtools`` ships it).
     """
     from arda.annotate.reference import load_reference
     from arda.refbuild.imgt import read_fasta

--- a/python/vdjtools/model/stitch.py
+++ b/python/vdjtools/model/stitch.py
@@ -57,7 +57,7 @@ def annotate(contigs: list[str], *, organism: str = "human") -> pl.DataFrame:
     """Annotate nt contigs with arda → a polars frame of the calls the scenario/EM path needs.
 
     Returns columns ``v_call, d_call, j_call, junction, junction_aa, productive`` (arda's best
-    alignment). arda is the ``[model]`` extra.
+    alignment). arda is a base dependency (ships with vdjtools).
     """
     import arda
 

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -11,6 +11,6 @@ int hamming(const std::string& a, const std::string& b) {
     return d;
 }
 
-const char* version() { return "2.3.0"; }
+const char* version() { return "2.3.1"; }
 
 }  // namespace vdjtools

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -11,6 +11,6 @@ int hamming(const std::string& a, const std::string& b) {
     return d;
 }
 
-const char* version() { return "2.3.1"; }
+const char* version() { return "2.4.0"; }
 
 }  // namespace vdjtools

--- a/tests/cpp/test_core.cpp
+++ b/tests/cpp/test_core.cpp
@@ -10,7 +10,7 @@ int main() {
     assert(hamming("CASSL", "CASSF") == 1);
     assert(hamming("CASSLAP", "CFSSLAP") == 1);
     assert(hamming("CASS", "CASSL") == -1);   // length mismatch
-    assert(std::string(version()) == "2.3.1");
+    assert(std::string(version()) == "2.4.0");
     std::puts("ok");
     return 0;
 }

--- a/tests/cpp/test_core.cpp
+++ b/tests/cpp/test_core.cpp
@@ -10,7 +10,7 @@ int main() {
     assert(hamming("CASSL", "CASSF") == 1);
     assert(hamming("CASSLAP", "CFSSLAP") == 1);
     assert(hamming("CASS", "CASSL") == -1);   // length mismatch
-    assert(std::string(version()) == "2.3.0");
+    assert(std::string(version()) == "2.3.1");
     std::puts("ok");
     return 0;
 }

--- a/tests/python/test_infer.py
+++ b/tests/python/test_infer.py
@@ -105,10 +105,12 @@ def test_vdj_estep_accumulates():
     m = from_olga(TRB, locus="TRB")
     prep = prepare(m)
     seq = min(generate(m, 60, seed=1, productive_only=True)["junction_nt"].to_list(), key=len)
-    counts = {name: defaultdict(float) for name in m.tables if name != "n_d"}
+    # Every VDJ scenario also harvests the D-count event, so ``n_d`` must have a bucket too
+    # (the E-step emits ``("n_d", (1,))`` per single-D scenario).
+    counts = {name: defaultdict(float) for name in m.tables}
     pg = _estep_seq(prep, seq, counts)
     assert pg > 0
-    for ev in ("d_gene", "d_del", "vd_ins", "dj_ins", "vd_dinucl", "dj_dinucl"):
+    for ev in ("d_gene", "d_del", "vd_ins", "dj_ins", "vd_dinucl", "dj_dinucl", "n_d"):
         assert counts[ev], f"{ev} soft counts were not accumulated"
 
 

--- a/tests/python/test_smoke.py
+++ b/tests/python/test_smoke.py
@@ -4,8 +4,8 @@ from vdjtools import _core
 
 
 def test_version():
-    assert vdjtools.__version__ == "2.3.1"
-    assert _core.version() == "2.3.1"
+    assert vdjtools.__version__ == "2.4.0"
+    assert _core.version() == "2.4.0"
 
 
 def test_hamming():
@@ -13,3 +13,28 @@ def test_hamming():
     assert _core.hamming("CASSL", "CASSF") == 1
     assert _core.hamming("CASS", "CASSL") == -1  # length mismatch
     assert vdjtools.hamming("AAA", "ABA") == 1   # re-exported at top level
+
+
+def test_arda_is_a_base_dependency():
+    """A plain ``pip install vdjtools`` must ship arda — i.e. the model engine AND the germline
+    reference. Downstream libraries (mirpy) depend on vdjtools *for* the germline reference and
+    cannot be expected to opt into an extra, so arda must never regress to an optional extra.
+    """
+    from importlib.metadata import requires
+
+    arda_reqs = [r for r in (requires("vdjtools") or [])
+                 if r.split(";")[0].strip().lower().startswith("arda-mapper")]
+    assert arda_reqs, "arda-mapper is not a vdjtools requirement at all"
+    # At least one arda requirement must be unconditional (no `extra == "..."` marker).
+    assert any("extra ==" not in r for r in arda_reqs), \
+        f"arda-mapper is gated behind an extra, so a plain install has no germline: {arda_reqs}"
+
+
+def test_plain_install_exposes_the_germline_reference():
+    """The contract mirpy relies on: germline V/D/J + CDR3 anchors resolve with no extras."""
+    from vdjtools.model.reference import load_germline
+
+    g = load_germline("TRB")
+    assert set(g["segment"].unique()) >= {"V", "D", "J"}
+    assert g.filter(g["segment"] == "V").height > 0
+    assert (g.filter(g["segment"] == "V")["cdr3_anchor"] >= 0).any()

--- a/tests/python/test_smoke.py
+++ b/tests/python/test_smoke.py
@@ -4,8 +4,8 @@ from vdjtools import _core
 
 
 def test_version():
-    assert vdjtools.__version__ == "2.3.0"
-    assert _core.version() == "2.3.0"
+    assert vdjtools.__version__ == "2.3.1"
+    assert _core.version() == "2.3.1"
 
 
 def test_hamming():


### PR DESCRIPTION
## v2.4.0 — arda becomes a base dependency (vdjtools now ships the germline reference)

Minor release off `dev`.

### The fix: arda is no longer optional
arda sat in the `[model]` extra, so a plain `pip install vdjtools` shipped the bundled models but **not the germline reference** — `model.reference.load_germline()` raised `ImportError`.

That broke the contract downstream libraries depend on. **mirpy** declares `vdjtools>=2.3.0` as a *base* dep explicitly for *"AIRR schema + IO, **germline reference**, Pgen"*, and had to work around the gap by **baking its own copies** at build time (`region_annotations.txt` via arda → BLOSUM62 germline distance matrices via BioPython) rather than just reading the reference from vdjtools.

vdjtools' own pyproject already stated the intent — parents are *"promoted from the extras to base deps as the phases that import them land (model → arda)"*. Phase 1 landed long ago; the promotion never happened.

### Why this is cheap
- arda-mapper ships **the same wheel matrix as vdjtools** (cp310–313 × macOS arm64 / manylinux / win_amd64).
- Its only runtime deps are `polars` + `typer` (already ours) + `requests`.
- It's imported **lazily** inside the functions that use it, so `import vdjtools` stays light.
- **MMseqs2 is only needed for arda's annotate path** — never for germline lookup, Pgen, generation, or the analytics.

### Changes
- `pyproject`: `arda-mapper>=2.5.3` → `[project].dependencies`. `[model]` kept as an **empty no-op alias** so existing `vdjtools[model]` pins (mirpy's build extra) still resolve. Dropped from `all`.
- Reworded everything that called arda optional (`reference` / `io` / `stitch` / `infer`, README, CLAUDE.md).
- **Two regression tests pin the contract** so it can't silently revert: arda-mapper must appear as an *unconditional* requirement (no `extra ==` marker), and `load_germline("TRB")` must return V/D/J + anchors from a plain install.

### Also in this release (was the held v2.3.1)
- arda floor bumped `>=2.5` → **`>=2.5.3`** (latest on PyPI); validated — no vdjtools code change needed.
- Fixed a **pre-existing** stale test (`test_vdj_estep_accumulates` dropped the `n_d` soft-count bucket the E-step legitimately harvests). The library was correct; only the test was stale. It shipped broken in v2.3.0 because the slow tier is deselected by default.

### Verification
- Fast suite: **393 passed** (incl. the 2 new contract tests)
- Full slow tier (excl. HF-network test): **17 passed**, incl. the stitch → arda-annotate round-trip
- C++ `ctest`: green

### Note for CI
`pip install -e ".[test]"` now pulls arda, so the germline tests **run** instead of skipping; arda fetches its IMGT reference once on first use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
