### PR TITLE
Release v2.5.1 — bump engines to latest (seqtree 0.4.0, vdjmatch 0.1.0, arda 2.5.5)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,7 +3,7 @@
 project = "vdjtools"
 author = "ISALGO laboratory"
 copyright = "2026, ISALGO laboratory"
-version = release = "2.5.0"
+version = release = "2.5.1"
 
 extensions = [
     "sphinx.ext.autodoc",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "vdjtools"  # if the PyPI name is taken, fall back to a distinct dist name (cf. arda -> arda-mapper)
-version = "2.5.0"
+version = "2.5.1"
 description = "TCR/BCR repertoire analysis — Pgen/generation/inference, diversity, overlap, biomarkers (Python + C++)"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -43,8 +43,8 @@ dependencies = [
     # metaclonotypes -- all advertised capabilities, and none has a fallback. Cheap: seqtree
     # itself has ZERO runtime deps and the same wheel matrix as vdjtools; vdjmatch is a
     # pure-python wheel needing only polars (ours) + seqtree. Both are imported lazily.
-    "seqtree>=0.3",
-    "vdjmatch>=0.0.1",
+    "seqtree>=0.4.0",
+    "vdjmatch>=0.1.0",
     # We declare huggingface_hub OURSELVES rather than borrowing seqtree's `[control]` extra:
     # it is genuinely OUR dependency (model/data.py imports hf_hub_download directly), and
     # tcrnet()'s DEFAULT path (control=None) scores each locus against a matched background

--- a/python/vdjtools/__init__.py
+++ b/python/vdjtools/__init__.py
@@ -13,5 +13,5 @@ vdjmatch/seqtree) until a feature that needs them is used.
 """
 from ._core import hamming
 
-__version__ = "2.5.0"
+__version__ = "2.5.1"
 __all__ = ["hamming", "__version__"]

--- a/src/core.cpp
+++ b/src/core.cpp
@@ -11,6 +11,6 @@ int hamming(const std::string& a, const std::string& b) {
     return d;
 }
 
-const char* version() { return "2.5.0"; }
+const char* version() { return "2.5.1"; }
 
 }  // namespace vdjtools

--- a/tests/cpp/test_core.cpp
+++ b/tests/cpp/test_core.cpp
@@ -10,7 +10,7 @@ int main() {
     assert(hamming("CASSL", "CASSF") == 1);
     assert(hamming("CASSLAP", "CFSSLAP") == 1);
     assert(hamming("CASS", "CASSL") == -1);   // length mismatch
-    assert(std::string(version()) == "2.5.0");
+    assert(std::string(version()) == "2.5.1");
     std::puts("ok");
     return 0;
 }

--- a/tests/python/test_smoke.py
+++ b/tests/python/test_smoke.py
@@ -4,8 +4,8 @@ from vdjtools import _core
 
 
 def test_version():
-    assert vdjtools.__version__ == "2.5.0"
-    assert _core.version() == "2.5.0"
+    assert vdjtools.__version__ == "2.5.1"
+    assert _core.version() == "2.5.1"
 
 
 def test_hamming():


### PR DESCRIPTION
## v2.5.1 — engine floors bumped to latest

All three antigenomics engines to their newest PyPI releases:

| Engine | Was | Now |
|---|---|---|
| arda-mapper | >=2.5.5 | **>=2.5.5** (already latest) |
| seqtree | >=0.3 | **>=0.4.0** |
| vdjmatch | >=0.0.1 | **>=0.1.0** |

`vdjmatch 0.1.0` itself requires `seqtree>=0.4.0`, so the floors are mutually consistent; seqtree 0.4.0 still has **zero** base runtime deps.

**No vdjtools code change was needed** — despite the seqtree 0.3→0.4 and vdjmatch 0.0.1→0.1.0 jumps, no API broke.

### Verification
- 396 fast tests
- Full slow tier (17) — incl. the stitch → arda-annotate round-trip and exhaustive Pgen
- C++ `ctest`
- CI green on all 6 jobs (Python 3.10/3.12 × Linux/macOS)

Base deps remain: `arda-mapper>=2.5.5`, `seqtree>=0.4.0`, `vdjmatch>=0.1.0`, `huggingface_hub`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)